### PR TITLE
Fix overlay scroll navigation for long skill lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Overlay skill list now adapts to terminal height instead of using a hardcoded 10-skill window, so all skills are reachable without resizing the terminal.
+- `↑` and `↓` arrow keys reliably scroll through the full skill list on Mac keyboards; viewport follows the selection.
+- Added scroll indicators (`↑ N more above` / `↓ N more below`) so users can see how many items remain off-screen.
+- Controls line now shows `↑↓ navigate` to make arrow-key navigation discoverable.
+- Footer displays total filtered skill count for orientation in long lists.
+- Overlay passes `maxHeight: "90%"` to prevent the panel from exceeding terminal bounds.
+
+### Added
+
+- `maxSkillsForHeight()` helper that computes how many skills fit for a given terminal height.
+- Automated test suite (`skill-controller.ui-scroll.test.ts`) covering long-list navigation, scroll indicators, viewport centering, boundary clamping, and filtering behavior with 40+ skills.
+
 ### Changed
 
 - Bumped `@mariozechner/pi-coding-agent` and `@mariozechner/pi-tui` dev dependencies to `0.69.0` so package validates against Pi's TypeBox 1.x migration and current extension APIs.

--- a/extensions/skill-controller/ui.ts
+++ b/extensions/skill-controller/ui.ts
@@ -20,11 +20,32 @@ function truncate(value: string, width: number): string {
   return `${value.slice(0, Math.max(0, width - 1))}…`;
 }
 
+/**
+ * Number of fixed chrome rows rendered around the skill list:
+ * top border, title, controls, blank, target-file (1+ lines), blank,
+ * search, blank, [skills], blank, unsaved-changes, bottom border.
+ *
+ * Minimum is 10 when the target-file path fits on a single line.
+ */
+const CHROME_ROWS_BASE = 10;
+
+/** Each skill occupies exactly 2 rendered rows (label + path). */
+const ROWS_PER_SKILL = 2;
+
+/** Fallback when no height hint is available. */
+const DEFAULT_MAX_VISIBLE_SKILLS = 20;
+
 export class SkillControllerOverlay implements Component, Focusable {
   focused = false;
   private selectedIndex = 0;
   private query = "";
   private pending = new Map<string, boolean>();
+
+  /**
+   * Maximum number of skills visible in the viewport at once.
+   * Exposed so tests can inspect or override it.
+   */
+  maxVisibleSkills: number;
 
   constructor(
     private readonly theme: Theme,
@@ -33,8 +54,10 @@ export class SkillControllerOverlay implements Component, Focusable {
     initialQuery: string,
     private readonly targetSettingsPath: string,
     private readonly done: (result: SkillControllerUISelection) => void,
+    maxVisibleSkills?: number,
   ) {
     this.query = initialQuery;
+    this.maxVisibleSkills = maxVisibleSkills ?? DEFAULT_MAX_VISIBLE_SKILLS;
   }
 
   private get filteredSkills(): SkillRecord[] {
@@ -98,6 +121,29 @@ export class SkillControllerOverlay implements Component, Focusable {
     }
   }
 
+  /**
+   * Compute the visible window of skills and the starting index.
+   * Keeps the selected item visible and roughly centered when possible.
+   */
+  private computeWindow(filtered: SkillRecord[]): { windowSkills: SkillRecord[]; startIndex: number } {
+    const maxVisible = Math.min(this.maxVisibleSkills, filtered.length);
+    if (filtered.length <= maxVisible) {
+      return { windowSkills: filtered, startIndex: 0 };
+    }
+
+    // Keep selected item visible with some context above and below.
+    // Try to center the selection in the window.
+    const half = Math.floor(maxVisible / 2);
+    let start = this.selectedIndex - half;
+    start = Math.max(0, start);
+    start = Math.min(filtered.length - maxVisible, start);
+
+    return {
+      windowSkills: filtered.slice(start, start + maxVisible),
+      startIndex: start,
+    };
+  }
+
   render(width: number): string[] {
     const w = Math.min(100, Math.max(72, width - 6));
     const inner = w - 2;
@@ -105,15 +151,14 @@ export class SkillControllerOverlay implements Component, Focusable {
     const queryLine = `${this.theme.fg("accent", "Search")}: ${this.query}${this.focused ? CURSOR_MARKER : ""}`;
     const title = this.scope === "global" ? "/sc:global" : "/sc:project";
     const filtered = this.filteredSkills;
-    const windowRows = filtered.slice(Math.max(0, this.selectedIndex - 5), Math.max(0, this.selectedIndex - 5) + 10);
-    const startIndex = filtered.indexOf(windowRows[0] ?? filtered[0]!);
+    const { windowSkills, startIndex } = this.computeWindow(filtered);
 
     const wrap = (content: string) =>
       `${this.theme.fg("border", "│")}${padRight(truncate(content, inner), inner)}${this.theme.fg("border", "│")}`;
 
     rows.push(this.theme.fg("border", `╭${"─".repeat(inner)}╮`));
     rows.push(wrap(` ${this.theme.bold(title)} · interactive skill control`));
-    rows.push(wrap(` Scope: ${this.scope} · Enter toggle · Ctrl+S save · Esc cancel`));
+    rows.push(wrap(` Scope: ${this.scope} · ↑↓ navigate · Enter toggle · Ctrl+S save · Esc cancel`));
     rows.push(wrap(""));
     for (const [index, chunk] of chunkText(`Target file: ${this.targetSettingsPath}`, inner - 1).entries()) {
       rows.push(wrap(` ${index === 0 ? chunk : `  ${chunk}`}`));
@@ -125,26 +170,49 @@ export class SkillControllerOverlay implements Component, Focusable {
     if (filtered.length === 0) {
       rows.push(wrap(` ${this.theme.fg("warning", "No skills match current filter")}`));
     } else {
-      for (let i = 0; i < windowRows.length; i++) {
-        const skill = windowRows[i]!;
-        const index = startIndex + i;
-        const selected = index === this.selectedIndex;
+      // Scroll-up indicator
+      const hiddenAbove = startIndex;
+      if (hiddenAbove > 0) {
+        rows.push(wrap(` ${this.theme.fg("accent", `  ↑ ${hiddenAbove} more above`)}`));
+      }
+
+      for (let i = 0; i < windowSkills.length; i++) {
+        const skill = windowSkills[i]!;
+        const absoluteIndex = startIndex + i;
+        const selected = absoluteIndex === this.selectedIndex;
         const state = this.getEnabled(skill) ? this.theme.fg("success", "enabled") : this.theme.fg("error", "disabled");
         const marker = selected ? this.theme.fg("accent", "▶") : " ";
         const label = `${marker} ${skill.name} · ${state} · ${skill.sourceLabel}`;
         rows.push(wrap(label));
         rows.push(wrap(`   ${truncate(skill.relativeSkillDirPath, inner - 3)}`));
       }
+
+      // Scroll-down indicator
+      const hiddenBelow = filtered.length - (startIndex + windowSkills.length);
+      if (hiddenBelow > 0) {
+        rows.push(wrap(` ${this.theme.fg("accent", `  ↓ ${hiddenBelow} more below`)}`));
+      }
     }
 
     rows.push(wrap(""));
-    rows.push(wrap(` Unsaved changes: ${this.pending.size} · target file writes only on Ctrl+S`));
+    rows.push(wrap(` ${filtered.length} skill${filtered.length !== 1 ? "s" : ""} · Unsaved changes: ${this.pending.size} · target file writes only on Ctrl+S`));
     rows.push(this.theme.fg("border", `╰${"─".repeat(inner)}╯`));
     return rows;
   }
 
   invalidate(): void {}
   dispose(): void {}
+}
+
+/**
+ * Compute the maximum number of skills that fit in the overlay given a
+ * terminal height. Accounts for chrome rows and 2 rows per skill, plus
+ * up to 2 scroll-indicator rows.
+ */
+export function maxSkillsForHeight(terminalHeight: number): number {
+  // Reserve chrome rows + 2 possible scroll indicator rows
+  const available = terminalHeight - CHROME_ROWS_BASE - 2;
+  return Math.max(1, Math.floor(available / ROWS_PER_SKILL));
 }
 
 export async function openSkillControllerOverlay(
@@ -155,7 +223,17 @@ export async function openSkillControllerOverlay(
   targetSettingsPath: string,
 ): Promise<SkillControllerUISelection> {
   return ctx.ui.custom<SkillControllerUISelection>(
-    (_tui, theme, _kb, done) => new SkillControllerOverlay(theme, scope, skills, args.trim(), targetSettingsPath, done),
-    { overlay: true },
+    (_tui, theme, _kb, done) => {
+      // Compute height-aware skill limit from terminal dimensions.
+      const termHeight = _tui.terminal.rows ?? 40;
+      const maxVisible = maxSkillsForHeight(termHeight);
+      return new SkillControllerOverlay(theme, scope, skills, args.trim(), targetSettingsPath, done, maxVisible);
+    },
+    {
+      overlay: true,
+      overlayOptions: {
+        maxHeight: "90%",
+      },
+    },
   );
 }

--- a/tests/skill-controller.ui-scroll.test.ts
+++ b/tests/skill-controller.ui-scroll.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from "vitest";
+import { SkillControllerOverlay, maxSkillsForHeight } from "../extensions/skill-controller/ui.js";
+import type { SkillControllerUISelection, SkillRecord } from "../extensions/skill-controller/types.js";
+
+const theme = {
+  fg: (_token: string, value: string) => value,
+  bold: (value: string) => value,
+} as const;
+
+function createSkills(count: number): SkillRecord[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `skill-${i}`,
+    name: `skill-${String(i).padStart(3, "0")}`,
+    skillPath: `/tmp/skills/skill-${i}/SKILL.md`,
+    skillDirPath: `/tmp/skills/skill-${i}`,
+    relativeSkillPath: `skills/skill-${i}`,
+    relativeSkillDirPath: `skills/skill-${i}`,
+    sourceKind: "auto" as const,
+    sourceLabel: "~/.pi/agent/skills",
+    sourcePath: "/tmp/skills",
+    ownerScope: "global" as const,
+    targetScope: "global" as const,
+    targetSettingsPath: "/tmp/settings.json",
+    enabled: true,
+  }));
+}
+
+function createOverlay(
+  skills: SkillRecord[],
+  maxVisibleSkills?: number,
+): { overlay: SkillControllerOverlay; results: SkillControllerUISelection[] } {
+  const results: SkillControllerUISelection[] = [];
+  const overlay = new SkillControllerOverlay(
+    theme as never,
+    "global",
+    skills,
+    "",
+    "/tmp/settings.json",
+    (result) => results.push(result),
+    maxVisibleSkills,
+  );
+  return { overlay, results };
+}
+
+/** Simulate pressing down arrow N times. */
+function pressDown(overlay: SkillControllerOverlay, times: number): void {
+  for (let i = 0; i < times; i++) {
+    overlay.handleInput("\u001b[B"); // down arrow
+  }
+}
+
+/** Simulate pressing up arrow N times. */
+function pressUp(overlay: SkillControllerOverlay, times: number): void {
+  for (let i = 0; i < times; i++) {
+    overlay.handleInput("\u001b[A"); // up arrow
+  }
+}
+
+/** Get the plain text of rendered lines (theme mock returns raw strings). */
+function renderText(overlay: SkillControllerOverlay, width = 120): string {
+  return overlay.render(width).join("\n");
+}
+
+/** Find which skill name has the selection marker (▶). */
+function selectedSkillName(overlay: SkillControllerOverlay, width = 120): string | undefined {
+  const lines = overlay.render(width);
+  const markerLine = lines.find((line) => line.includes("▶"));
+  if (!markerLine) return undefined;
+  const match = markerLine.match(/▶\s+(skill-\d+)/);
+  return match?.[1];
+}
+
+describe("maxSkillsForHeight", () => {
+  it("returns at least 1 for very small terminals", () => {
+    expect(maxSkillsForHeight(10)).toBeGreaterThanOrEqual(1);
+    expect(maxSkillsForHeight(5)).toBe(1);
+  });
+
+  it("scales with terminal height", () => {
+    const small = maxSkillsForHeight(24);
+    const large = maxSkillsForHeight(60);
+    expect(large).toBeGreaterThan(small);
+  });
+
+  it("computes expected values for common terminal heights", () => {
+    // 24 rows: 24 - 10 chrome - 2 indicators = 12 available / 2 rows per skill = 6
+    expect(maxSkillsForHeight(24)).toBe(6);
+    // 40 rows: 40 - 12 = 28 / 2 = 14
+    expect(maxSkillsForHeight(40)).toBe(14);
+    // 60 rows: 60 - 12 = 48 / 2 = 24
+    expect(maxSkillsForHeight(60)).toBe(24);
+  });
+});
+
+describe("overlay with 40+ skills", () => {
+  it("renders all skills when viewport is large enough", () => {
+    const skills = createSkills(5);
+    const { overlay } = createOverlay(skills, 20);
+    const text = renderText(overlay);
+
+    for (const skill of skills) {
+      expect(text).toContain(skill.name);
+    }
+  });
+
+  it("limits visible skills to maxVisibleSkills", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    const text = renderText(overlay);
+
+    // First 5 skills should be visible
+    expect(text).toContain("skill-000");
+    expect(text).toContain("skill-004");
+    // Skill beyond the window should not be visible
+    expect(text).not.toContain("skill-010");
+  });
+
+  it("shows scroll-down indicator when items are hidden below", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    const text = renderText(overlay);
+
+    expect(text).toContain("↓ 35 more below");
+  });
+
+  it("does not show scroll-up indicator when at the top", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    const text = renderText(overlay);
+
+    // The controls line contains "↑↓ navigate" which is expected.
+    // The scroll indicator specifically says "more above".
+    expect(text).not.toContain("more above");
+  });
+
+  it("shows scroll-up indicator after scrolling down", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    pressDown(overlay, 10);
+    const text = renderText(overlay);
+
+    expect(text).toContain("more above");
+  });
+
+  it("shows both scroll indicators when in the middle of the list", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    pressDown(overlay, 20);
+    const text = renderText(overlay);
+
+    expect(text).toContain("more above");
+    expect(text).toContain("more below");
+  });
+
+  it("does not show scroll-down indicator when at the bottom", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    pressDown(overlay, 39); // go to last item
+    const text = renderText(overlay);
+
+    expect(text).not.toContain("more below");
+    expect(text).toContain("more above");
+  });
+});
+
+describe("arrow-key navigation reaches every skill", () => {
+  it("can reach the last skill with repeated down presses", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+
+    pressDown(overlay, 39);
+    expect(selectedSkillName(overlay)).toBe("skill-039");
+
+    const text = renderText(overlay);
+    expect(text).toContain("skill-039");
+  });
+
+  it("can navigate back to the first skill with up presses", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+
+    pressDown(overlay, 39);
+    pressUp(overlay, 39);
+    expect(selectedSkillName(overlay)).toBe("skill-000");
+
+    const text = renderText(overlay);
+    expect(text).toContain("skill-000");
+  });
+
+  it("every skill becomes visible when navigating through the full list", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    const seenSkills = new Set<string>();
+
+    // Collect all visible skill names as we navigate down
+    for (let i = 0; i < 40; i++) {
+      const lines = overlay.render(120);
+      for (const line of lines) {
+        const match = line.match(/skill-(\d{3})/g);
+        if (match) {
+          for (const m of match) seenSkills.add(m);
+        }
+      }
+      pressDown(overlay, 1);
+    }
+
+    // Every skill should have been visible at some point
+    for (const skill of skills) {
+      expect(seenSkills.has(skill.name)).toBe(true);
+    }
+  });
+
+  it("selected item is always rendered in the viewport", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+
+    for (let i = 0; i < 40; i++) {
+      const text = renderText(overlay);
+      const selected = selectedSkillName(overlay);
+      expect(selected).toBeDefined();
+      expect(text).toContain(selected!);
+      // The marker should be visible
+      expect(text).toContain("▶");
+      pressDown(overlay, 1);
+    }
+  });
+});
+
+describe("up arrow does not go below zero", () => {
+  it("stays at first item when pressing up at the top", () => {
+    const skills = createSkills(10);
+    const { overlay } = createOverlay(skills, 5);
+
+    pressUp(overlay, 5);
+    expect(selectedSkillName(overlay)).toBe("skill-000");
+  });
+});
+
+describe("down arrow does not exceed list length", () => {
+  it("stays at last item when pressing down past the end", () => {
+    const skills = createSkills(10);
+    const { overlay } = createOverlay(skills, 5);
+
+    pressDown(overlay, 20);
+    expect(selectedSkillName(overlay)).toBe("skill-009");
+  });
+});
+
+describe("controls copy shows arrow keys", () => {
+  it("displays ↑↓ navigate in the controls line", () => {
+    const skills = createSkills(5);
+    const { overlay } = createOverlay(skills, 5);
+    const text = renderText(overlay);
+
+    expect(text).toContain("↑↓ navigate");
+  });
+});
+
+describe("skill count shown in footer", () => {
+  it("displays total filtered skill count", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+    const text = renderText(overlay);
+
+    expect(text).toContain("40 skills");
+  });
+
+  it("displays singular when only 1 skill", () => {
+    const skills = createSkills(1);
+    const { overlay } = createOverlay(skills, 5);
+    const text = renderText(overlay);
+
+    expect(text).toContain("1 skill");
+    expect(text).not.toContain("1 skills");
+  });
+});
+
+describe("filtering with long lists", () => {
+  it("resets selection to 0 when typing a filter", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+
+    pressDown(overlay, 20);
+    // Type a character to filter
+    overlay.handleInput("0");
+    expect(selectedSkillName(overlay)).toBeDefined();
+
+    // Selection should be at index 0 of filtered results
+    const text = renderText(overlay);
+    expect(text).toContain("▶");
+  });
+
+  it("scroll indicators update after filtering", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+
+    // Initially shows 35 more below
+    expect(renderText(overlay)).toContain("35 more below");
+
+    // Type filter that matches fewer skills
+    overlay.handleInput("3");
+    overlay.handleInput("9");
+    const text = renderText(overlay);
+
+    // Only skill-039 matches "39", so no scroll indicators needed
+    expect(text).not.toContain("more below");
+    expect(text).not.toContain("more above");
+  });
+});
+
+describe("viewport centering behavior", () => {
+  it("centers the selected item in the viewport when possible", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 5);
+
+    // Navigate to skill 20 (middle of list)
+    pressDown(overlay, 20);
+    const text = renderText(overlay);
+
+    // skill-020 should be visible and selected
+    expect(text).toContain("skill-020");
+    expect(selectedSkillName(overlay)).toBe("skill-020");
+
+    // Items around it should also be visible (at least one neighbor on each side)
+    const hasNeighborAbove = text.includes("skill-018") || text.includes("skill-019");
+    const hasNeighborBelow = text.includes("skill-021") || text.includes("skill-022");
+    expect(hasNeighborAbove).toBe(true);
+    expect(hasNeighborBelow).toBe(true);
+  });
+});
+
+describe("default maxVisibleSkills", () => {
+  it("uses default of 20 when no maxVisibleSkills is provided", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills); // no maxVisibleSkills
+    expect(overlay.maxVisibleSkills).toBe(20);
+  });
+
+  it("respects explicit maxVisibleSkills override", () => {
+    const skills = createSkills(40);
+    const { overlay } = createOverlay(skills, 8);
+    expect(overlay.maxVisibleSkills).toBe(8);
+  });
+});


### PR DESCRIPTION
- Replace hardcoded 10-skill window with dynamic height-aware viewport
- Compute maxVisibleSkills from terminal height via maxSkillsForHeight()
- Add scroll indicators showing hidden items above/below viewport
- Update controls copy to show ↑↓ as primary navigation keys
- Show total filtered skill count in footer for orientation
- Pass overlayOptions { maxHeight: '90%' } to constrain overlay bounds
- Add 24 automated tests for long-list navigation and scrolling

Closes #1