### PR TITLE
Fix ~/ path expansion in skill discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `~/` paths in settings skill entries and local package sources now expand to the current home directory before discovery.
 - Overlay skill list now adapts to terminal height instead of using a hardcoded 10-skill window, so all skills are reachable without resizing the terminal.
 - `↑` and `↓` arrow keys reliably scroll through the full skill list on Mac keyboards; viewport follows the selection.
 - Added scroll indicators (`↑ N more above` / `↓ N more below`) so users can see how many items remain off-screen.

--- a/extensions/skill-controller/discovery.ts
+++ b/extensions/skill-controller/discovery.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { getPackageIdentity, resolvePackageRoot } from "./package-source.js";
+import { expandHomePathSelector, resolveSettingsPath } from "./path-utils.js";
 import { evaluateExactPathEntries, normalizeExactPath } from "./serialization.js";
 import { loadScopeSettings } from "./settings-store.js";
 import type {
@@ -104,11 +105,12 @@ function discoverFromTopLevelSkills(
   skills: SkillRecord[],
   seen: Set<string>,
 ): void {
+  const expandedSkillEntries = scopeSettings.data.skills?.map((entry) => expandHomePathSelector(entry, scopeSettings.homeDir));
   for (const entry of scopeSettings.data.skills ?? []) {
     if (entry.startsWith("+") || entry.startsWith("-") || entry.startsWith("!") || entry.includes("*")) {
       continue;
     }
-    const resolved = path.resolve(scopeSettings.baseDir, entry);
+    const resolved = resolveSettingsPath(scopeSettings.baseDir, entry, scopeSettings.homeDir);
     for (const skillPath of collectSkillDirs(resolved, fsApi)) {
       const skillDirPath = skillPath.endsWith(".md") ? skillPath : skillPath;
       const relativeSkillPath = normalizeExactPath(scopeSettings.baseDir, skillDirPath);
@@ -125,7 +127,7 @@ function discoverFromTopLevelSkills(
         ownerScope: scopeSettings.scope,
         targetScope,
         targetSettingsPath: targetScope === "global" ? scopeSettings.settingsPath : path.join(path.dirname(scopeSettings.baseDir), ".pi", "settings.json"),
-        enabled: evaluateExactPathEntries(scopeSettings.data.skills, relativeSkillPath, true),
+        enabled: evaluateExactPathEntries(expandedSkillEntries, relativeSkillPath, true),
       }, seen);
     }
   }
@@ -170,7 +172,7 @@ function discoverFromPackages(
 ): void {
   for (const [entryIndex, pkg] of (scopeSettings.data.packages ?? []).entries()) {
     const source = typeof pkg === "string" ? pkg : pkg.source;
-    const identity = getPackageIdentity(source, scopeSettings.baseDir);
+    const identity = getPackageIdentity(source, scopeSettings.baseDir, scopeSettings.homeDir);
     const packageRoot = resolvePackageRoot(source, scopeSettings, {
       execFileSync: deps.execFileSync,
       existsSync: fsApi.existsSync,

--- a/extensions/skill-controller/package-source.ts
+++ b/extensions/skill-controller/package-source.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveSettingsPath } from "./path-utils.js";
 import type {
   ScopeSettings,
   SettingsData,
@@ -108,7 +109,7 @@ export function parseGitPackageSource(source: string): ParsedGitSource | null {
   };
 }
 
-export function getPackageIdentity(source: string, settingsBaseDir: string): string {
+export function getPackageIdentity(source: string, settingsBaseDir: string, homeDir = process.env.HOME ?? ""): string {
   if (source.startsWith("npm:")) {
     return `npm:${parseNpmPackageName(source)}`;
   }
@@ -118,12 +119,12 @@ export function getPackageIdentity(source: string, settingsBaseDir: string): str
     return `git:${gitSource.host}/${gitSource.repoPath}`;
   }
 
-  return `local:${normalizeSlashes(path.resolve(settingsBaseDir, source))}`;
+  return `local:${normalizeSlashes(resolveSettingsPath(settingsBaseDir, source, homeDir))}`;
 }
 
-export function getPackageEntryIdentity(entry: SettingsPackageEntry, settingsBaseDir: string): string {
+export function getPackageEntryIdentity(entry: SettingsPackageEntry, settingsBaseDir: string, homeDir = process.env.HOME ?? ""): string {
   const source = typeof entry === "string" ? entry : entry.source;
-  return getPackageIdentity(source, settingsBaseDir);
+  return getPackageIdentity(source, settingsBaseDir, homeDir);
 }
 
 function getNpmCommand(settings: SettingsData): { command: string; args: string[] } {
@@ -181,7 +182,7 @@ export function resolvePackageRoot(
     if (gitSource) {
       packageRoot = path.join(scopeSettings.baseDir, "git", gitSource.host, ...gitSource.repoPath.split("/"));
     } else {
-      packageRoot = path.resolve(scopeSettings.baseDir, source);
+      packageRoot = resolveSettingsPath(scopeSettings.baseDir, source, scopeSettings.homeDir);
     }
   }
 

--- a/extensions/skill-controller/path-utils.ts
+++ b/extensions/skill-controller/path-utils.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+
+function expandHomePath(value: string, homeDir: string): string {
+  if (!homeDir) return value;
+  if (value === "~") return homeDir;
+  if (value.startsWith(`~${path.sep}`) || value.startsWith("~/")) {
+    return path.join(homeDir, value.slice(2));
+  }
+  return value;
+}
+
+export function expandHomePathSelector(value: string, homeDir: string): string {
+  const prefix = value[0];
+  if (prefix === "+" || prefix === "-" || prefix === "!") {
+    return `${prefix}${expandHomePath(value.slice(1), homeDir)}`;
+  }
+  return expandHomePath(value, homeDir);
+}
+
+export function resolveSettingsPath(baseDir: string, value: string, homeDir: string): string {
+  return path.resolve(baseDir, expandHomePath(value, homeDir));
+}

--- a/extensions/skill-controller/serialization.ts
+++ b/extensions/skill-controller/serialization.ts
@@ -110,6 +110,7 @@ export function updatePackageSkillState(
   packages: SettingsPackageEntry[],
   packageIdentity: string,
   settingsBaseDir: string,
+  settingsHomeDir: string,
   relativeSkillDirPath: string,
   enabled: boolean,
   fallbackSource: string,
@@ -117,7 +118,7 @@ export function updatePackageSkillState(
 ): SettingsPackageEntry[] {
   const nextPackages = [...packages];
   const index = nextPackages.findIndex(
-    (entry) => getPackageEntryIdentity(entry, settingsBaseDir) === packageIdentity,
+    (entry) => getPackageEntryIdentity(entry, settingsBaseDir, settingsHomeDir) === packageIdentity,
   );
   const current = index >= 0 ? toObjectEntry(nextPackages[index]!) : { source: fallbackSource };
 
@@ -187,6 +188,7 @@ export function applySkillEnabledState(
       settings.data.packages ?? [],
       packageRef.identity,
       settings.baseDir,
+      settings.homeDir,
       skill.relativeSkillDirPath,
       enabled,
       normalizePackageSourceForScope(packageRef, settings),

--- a/extensions/skill-controller/settings-store.ts
+++ b/extensions/skill-controller/settings-store.ts
@@ -41,6 +41,7 @@ export function loadScopeSettings(
     scope,
     settingsPath,
     baseDir: path.dirname(settingsPath),
+    homeDir,
     exists,
     data,
   };

--- a/extensions/skill-controller/types.ts
+++ b/extensions/skill-controller/types.ts
@@ -23,6 +23,7 @@ export interface ScopeSettings {
   scope: Scope;
   settingsPath: string;
   baseDir: string;
+  homeDir: string;
   exists: boolean;
   data: SettingsData;
 }

--- a/tests/skill-controller.discovery.test.ts
+++ b/tests/skill-controller.discovery.test.ts
@@ -89,6 +89,46 @@ describe("skill discovery", () => {
     expect(gitSkill?.packageRef?.packageRoot).toBe(gitPackageDir);
   });
 
+  it("expands ~/ entries in top-level settings skills", () => {
+    const fixture = createFixtureRoot();
+    const homeSkillsDir = path.join(fixture.homeDir, "Dev", "magi-skills", "skills");
+
+    writeSkill(path.join(homeSkillsDir, "home-skill"), "home-skill");
+    writeJson(path.join(fixture.homeDir, ".pi", "agent", "settings.json"), {
+      skills: ["~/Dev/magi-skills/skills"],
+    });
+
+    const result = discoverSkillsForScope("global", {
+      cwd: fixture.repoDir,
+      homeDir: fixture.homeDir,
+    });
+
+    const skill = result.skills.find((entry) => entry.name === "home-skill");
+    expect(skill?.sourceKind).toBe("settings");
+    expect(skill?.skillDirPath).toBe(path.join(homeSkillsDir, "home-skill"));
+    expect(skill?.enabled).toBe(true);
+  });
+
+  it("expands ~/ local package sources", () => {
+    const fixture = createFixtureRoot();
+    const packageDir = path.join(fixture.homeDir, "Dev", "fixture-package");
+
+    writePackage(packageDir, ["home-package-skill"]);
+    writeJson(path.join(fixture.homeDir, ".pi", "agent", "settings.json"), {
+      packages: ["~/Dev/fixture-package"],
+    });
+
+    const result = discoverSkillsForScope("global", {
+      cwd: fixture.repoDir,
+      homeDir: fixture.homeDir,
+    });
+
+    const skill = result.skills.find((entry) => entry.name === "home-package-skill");
+    expect(skill?.sourceKind).toBe("package");
+    expect(skill?.packageRef?.identity).toBe(`local:${packageDir}`);
+    expect(skill?.packageRef?.packageRoot).toBe(packageDir);
+  });
+
   it("discovers globally installed scoped npm package skills", () => {
     const fixture = createFixtureRoot();
     const globalNpmRoot = path.join(fixture.rootDir, "global-npm", "node_modules");


### PR DESCRIPTION
## Summary
- Expand `~/` and `~` path entries before resolving settings-listed skills.
- Expand local package sources before package root resolution and package identity matching.
- Add focused discovery tests covering top-level `skills` entries and local package `source` values using `~/`.
- Update changelog under Unreleased / Fixed.

## Verification
- `npm run check`
  - `tsc --noEmit` passed
  - `vitest --run` passed: 4 files, 45 tests

Closes #3
