### PR TITLE
Fix skill controller modal scrolling overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added scroll indicators (`↑ N more above` / `↓ N more below`) so users can see how many items remain off-screen.
 - Controls line now shows `↑↓ navigate` to make arrow-key navigation discoverable.
 - Footer displays total filtered skill count for orientation in long lists.
-- Overlay passes `maxHeight: "90%"` to prevent the panel from exceeding terminal bounds.
+- Overlay passes `maxHeight: "90%"` and computes the skill viewport against the same cap, including fixed chrome and scroll-indicator rows, to keep footer/help controls visible when many skills overflow.
 
 ### Added
 

--- a/extensions/skill-controller/ui.ts
+++ b/extensions/skill-controller/ui.ts
@@ -25,9 +25,9 @@ function truncate(value: string, width: number): string {
  * top border, title, controls, blank, target-file (1+ lines), blank,
  * search, blank, [skills], blank, unsaved-changes, bottom border.
  *
- * Minimum is 10 when the target-file path fits on a single line.
+ * Minimum is 11 when the target-file path fits on a single line.
  */
-const CHROME_ROWS_BASE = 10;
+const CHROME_ROWS_BASE = 11;
 
 /** Each skill occupies exactly 2 rendered rows (label + path). */
 const ROWS_PER_SKILL = 2;
@@ -205,14 +205,19 @@ export class SkillControllerOverlay implements Component, Focusable {
 }
 
 /**
- * Compute the maximum number of skills that fit in the overlay given a
- * terminal height. Accounts for chrome rows and 2 rows per skill, plus
- * up to 2 scroll-indicator rows.
+ * Compute the maximum number of skills that fit in the overlay given an
+ * available overlay height. Accounts for chrome rows and 2 rows per skill,
+ * plus up to 2 scroll-indicator rows.
  */
-export function maxSkillsForHeight(terminalHeight: number): number {
+export function maxSkillsForHeight(overlayHeight: number): number {
   // Reserve chrome rows + 2 possible scroll indicator rows
-  const available = terminalHeight - CHROME_ROWS_BASE - 2;
+  const available = overlayHeight - CHROME_ROWS_BASE - 2;
   return Math.max(1, Math.floor(available / ROWS_PER_SKILL));
+}
+
+/** Compute the skill viewport against the same 90% terminal cap used by the overlay. */
+export function maxSkillsForTerminalRows(terminalRows: number): number {
+  return maxSkillsForHeight(Math.max(1, Math.floor(terminalRows * 0.9)));
 }
 
 export async function openSkillControllerOverlay(
@@ -224,9 +229,9 @@ export async function openSkillControllerOverlay(
 ): Promise<SkillControllerUISelection> {
   return ctx.ui.custom<SkillControllerUISelection>(
     (_tui, theme, _kb, done) => {
-      // Compute height-aware skill limit from terminal dimensions.
+      // Compute height-aware skill limit from the same 90% cap used by the overlay.
       const termHeight = _tui.terminal.rows ?? 40;
-      const maxVisible = maxSkillsForHeight(termHeight);
+      const maxVisible = maxSkillsForTerminalRows(termHeight);
       return new SkillControllerOverlay(theme, scope, skills, args.trim(), targetSettingsPath, done, maxVisible);
     },
     {

--- a/tests/skill-controller.ui-scroll.test.ts
+++ b/tests/skill-controller.ui-scroll.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SkillControllerOverlay, maxSkillsForHeight } from "../extensions/skill-controller/ui.js";
+import { SkillControllerOverlay, maxSkillsForHeight, maxSkillsForTerminalRows } from "../extensions/skill-controller/ui.js";
 import type { SkillControllerUISelection, SkillRecord } from "../extensions/skill-controller/types.js";
 
 const theme = {
@@ -71,6 +71,29 @@ function selectedSkillName(overlay: SkillControllerOverlay, width = 120): string
 }
 
 describe("maxSkillsForHeight", () => {
+  it("keeps the rendered list within a 90% overlay height", () => {
+    const skills = createSkills(40);
+    const overlayHeight = Math.floor(40 * 0.9);
+    const maxVisible = maxSkillsForTerminalRows(40);
+    const { overlay } = createOverlay(skills, maxVisible);
+
+    expect(overlay.render(120).length).toBeLessThanOrEqual(overlayHeight);
+  });
+
+  it("keeps the rendered middle-scroll list within a 90% overlay height", () => {
+    const skills = createSkills(40);
+    const overlayHeight = Math.floor(40 * 0.9);
+    const maxVisible = maxSkillsForTerminalRows(40);
+    const { overlay } = createOverlay(skills, maxVisible);
+
+    pressDown(overlay, 20);
+    const text = renderText(overlay);
+
+    expect(text).toContain("more above");
+    expect(text).toContain("more below");
+    expect(overlay.render(120).length).toBeLessThanOrEqual(overlayHeight);
+  });
+
   it("returns at least 1 for very small terminals", () => {
     expect(maxSkillsForHeight(10)).toBeGreaterThanOrEqual(1);
     expect(maxSkillsForHeight(5)).toBe(1);
@@ -83,12 +106,12 @@ describe("maxSkillsForHeight", () => {
   });
 
   it("computes expected values for common terminal heights", () => {
-    // 24 rows: 24 - 10 chrome - 2 indicators = 12 available / 2 rows per skill = 6
-    expect(maxSkillsForHeight(24)).toBe(6);
-    // 40 rows: 40 - 12 = 28 / 2 = 14
-    expect(maxSkillsForHeight(40)).toBe(14);
-    // 60 rows: 60 - 12 = 48 / 2 = 24
-    expect(maxSkillsForHeight(60)).toBe(24);
+    // 24 rows: 24 - 11 chrome - 2 indicators = 11 available / 2 rows per skill = 5
+    expect(maxSkillsForHeight(24)).toBe(5);
+    // 40 rows: 40 - 13 = 27 / 2 = 13
+    expect(maxSkillsForHeight(40)).toBe(13);
+    // 60 rows: 60 - 13 = 47 / 2 = 23
+    expect(maxSkillsForHeight(60)).toBe(23);
   });
 });
 


### PR DESCRIPTION
## Summary
- compute the visible skill viewport against the overlay's 90% terminal-height cap
- keep long skill lists scrollable without clipping footer/help controls
- add regression coverage for 40-skill overflow rendering
- update CHANGELOG.md

## Verification
- gh auth status
- git rev-parse --is-inside-work-tree
- npx vitest --run tests/skill-controller.ui-scroll.test.ts (failed before fix: maxSkillsForTerminalRows missing)
- npx vitest --run tests/skill-controller.ui-scroll.test.ts
- npm run typecheck
- npm test
- npm run check
- npm pack --dry-run

Closes #5