### PR TITLE
Add skill overlay bulk controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Skill controller overlay bulk controls: `Ctrl+A` enables and `Ctrl+D` disables all currently filtered skills in pending state, with writes still deferred until `Ctrl+S`.
+- README and overlay help text now document filtered bulk enable/disable semantics.
 - Generated hierarchical `AGENTS.md` repo guidance for root, skill-controller extension code, and tests.
 - `maxSkillsForHeight()` helper that computes how many skills fit for a given terminal height.
 - Automated test suite (`skill-controller.ui-scroll.test.ts`) covering long-list navigation, scroll indicators, viewport centering, boundary clamping, and filtering behavior with 40+ skills.

--- a/README.md
+++ b/README.md
@@ -70,12 +70,16 @@ Keys:
 - type text to filter
 - `Backspace` edit filter
 - `Enter` toggle selected skill in memory only
+- `Ctrl+A` enable all currently filtered skills in memory only
+- `Ctrl+D` disable all currently filtered skills in memory only
 - `Ctrl+S` save to settings file
 - `Esc` cancel without writing
 
 Important behavior:
 
-- toggles do **not** write on selection
+- toggles and bulk actions do **not** write on selection
+- bulk actions apply to the current filtered skill list
+- individual `Enter` toggles still work after a bulk action and determine final pending state
 - write happens only on `Ctrl+S`
 - cancel path leaves files unchanged
 - success message reports scope, resulting state, and exact file path written

--- a/extensions/skill-controller/ui.ts
+++ b/extensions/skill-controller/ui.ts
@@ -22,12 +22,12 @@ function truncate(value: string, width: number): string {
 
 /**
  * Number of fixed chrome rows rendered around the skill list:
- * top border, title, controls, blank, target-file (1+ lines), blank,
+ * top border, title, controls (2 rows), blank, target-file (1+ lines), blank,
  * search, blank, [skills], blank, unsaved-changes, bottom border.
  *
- * Minimum is 11 when the target-file path fits on a single line.
+ * Minimum is 12 when the target-file path fits on a single line.
  */
-const CHROME_ROWS_BASE = 11;
+const CHROME_ROWS_BASE = 12;
 
 /** Each skill occupies exactly 2 rendered rows (label + path). */
 const ROWS_PER_SKILL = 2;
@@ -79,10 +79,24 @@ export class SkillControllerOverlay implements Component, Focusable {
     return this.pending.get(skill.id) ?? skill.enabled;
   }
 
+  private setEffectivePending(skill: SkillRecord, enabled: boolean): void {
+    if (enabled === skill.enabled) {
+      this.pending.delete(skill.id);
+      return;
+    }
+    this.pending.set(skill.id, enabled);
+  }
+
   private toggleCurrent(): void {
     const skill = this.getCurrentSkill();
     if (!skill) return;
-    this.pending.set(skill.id, !this.getEnabled(skill));
+    this.setEffectivePending(skill, !this.getEnabled(skill));
+  }
+
+  private setFilteredEnabled(enabled: boolean): void {
+    for (const skill of this.filteredSkills) {
+      this.setEffectivePending(skill, enabled);
+    }
   }
 
   handleInput(data: string): void {
@@ -96,6 +110,14 @@ export class SkillControllerOverlay implements Component, Focusable {
         enabled,
       }));
       this.done({ type: "save", changes });
+      return;
+    }
+    if (matchesKey(data, "ctrl+a")) {
+      this.setFilteredEnabled(true);
+      return;
+    }
+    if (matchesKey(data, "ctrl+d")) {
+      this.setFilteredEnabled(false);
       return;
     }
     if (matchesKey(data, "enter")) {
@@ -159,6 +181,7 @@ export class SkillControllerOverlay implements Component, Focusable {
     rows.push(this.theme.fg("border", `╭${"─".repeat(inner)}╮`));
     rows.push(wrap(` ${this.theme.bold(title)} · interactive skill control`));
     rows.push(wrap(` Scope: ${this.scope} · ↑↓ navigate · Enter toggle · Ctrl+S save · Esc cancel`));
+    rows.push(wrap(" Ctrl+A enable filtered · Ctrl+D disable filtered · bulk writes only on Ctrl+S"));
     rows.push(wrap(""));
     for (const [index, chunk] of chunkText(`Target file: ${this.targetSettingsPath}`, inner - 1).entries()) {
       rows.push(wrap(` ${index === 0 ? chunk : `  ${chunk}`}`));

--- a/tests/skill-controller.ui-scroll.test.ts
+++ b/tests/skill-controller.ui-scroll.test.ts
@@ -365,3 +365,99 @@ describe("default maxVisibleSkills", () => {
     expect(overlay.maxVisibleSkills).toBe(8);
   });
 });
+
+describe("bulk enable and disable controls", () => {
+  it("bulk disables filtered skills only when saved", () => {
+    const skills = createSkills(4);
+    const { overlay, results } = createOverlay(skills);
+
+    overlay.handleInput("\u0004"); // Ctrl+D disables all currently filtered skills.
+
+    expect(results).toEqual([]);
+    expect(renderText(overlay)).toContain("Unsaved changes: 4");
+
+    overlay.handleInput("\u0013"); // Ctrl+S
+    expect(results).toEqual([
+      {
+        type: "save",
+        changes: skills.map((skill) => ({ skillId: skill.id, enabled: false })),
+      },
+    ]);
+  });
+
+  it("bulk enables filtered skills only when saved", () => {
+    const skills = createSkills(4).map((skill) => ({ ...skill, enabled: false }));
+    const { overlay, results } = createOverlay(skills);
+
+    overlay.handleInput("\u0001"); // Ctrl+A enables all currently filtered skills.
+
+    expect(results).toEqual([]);
+    expect(renderText(overlay)).toContain("Unsaved changes: 4");
+
+    overlay.handleInput("\u0013"); // Ctrl+S
+    expect(results).toEqual([
+      {
+        type: "save",
+        changes: skills.map((skill) => ({ skillId: skill.id, enabled: true })),
+      },
+    ]);
+  });
+
+  it("allows individual toggles after a bulk action to decide final state", () => {
+    const skills = createSkills(3);
+    const { overlay, results } = createOverlay(skills);
+
+    overlay.handleInput("\u0004"); // Ctrl+D
+    overlay.handleInput("\r"); // Enter toggles selected skill back to enabled.
+    overlay.handleInput("\u0013"); // Ctrl+S
+
+    expect(results).toEqual([
+      {
+        type: "save",
+        changes: [
+          { skillId: "skill-1", enabled: false },
+          { skillId: "skill-2", enabled: false },
+        ],
+      },
+    ]);
+  });
+
+  it("applies bulk actions to the current filtered skill list", () => {
+    const skills = createSkills(12);
+    const { overlay, results } = createOverlay(skills);
+
+    overlay.handleInput("1");
+    overlay.handleInput("\u0004"); // Ctrl+D
+    overlay.handleInput("\u0013"); // Ctrl+S
+
+    expect(results).toEqual([
+      {
+        type: "save",
+        changes: [
+          { skillId: "skill-1", enabled: false },
+          { skillId: "skill-10", enabled: false },
+          { skillId: "skill-11", enabled: false },
+        ],
+      },
+    ]);
+  });
+
+  it("cancels bulk pending changes on Esc", () => {
+    const skills = createSkills(3);
+    const { overlay, results } = createOverlay(skills);
+
+    overlay.handleInput("\u0004"); // Ctrl+D
+    overlay.handleInput("\u001b"); // Esc
+
+    expect(results).toEqual([{ type: "cancel", changes: [] }]);
+  });
+
+  it("documents bulk controls in the overlay help text", () => {
+    const skills = createSkills(3);
+    const { overlay } = createOverlay(skills);
+    const text = renderText(overlay);
+
+    expect(text).toContain("Ctrl+A enable filtered");
+    expect(text).toContain("Ctrl+D disable filtered");
+  });
+});


### PR DESCRIPTION
## Summary
- Add Ctrl+A/Ctrl+D overlay controls for enabling/disabling the current filtered skill list in pending state only
- Preserve deferred writes until Ctrl+S and effective pending diff counts
- Document bulk controls in README and changelog

## Verification
- npm test -- tests/skill-controller.ui-scroll.test.ts
- npm run check

Closes #8