### PR TITLE
Improve skill-controller modal list spacing and visual formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added scroll indicators (`↑ N more above` / `↓ N more below`) so users can see how many items remain off-screen.
 - Controls line now shows `↑↓ navigate` to make arrow-key navigation discoverable.
 - Footer displays total filtered skill count for orientation in long lists.
+- Skill-controller modal list entries now split name, enabled state/source, and relative path across separate rows for less dense scanning while preserving existing controls and filtering behavior.
 - Overlay passes `maxHeight: "90%"` and computes the skill viewport against the same cap, including fixed chrome and scroll-indicator rows, to keep footer/help controls visible when many skills overflow.
 
 ### Added

--- a/extensions/skill-controller/ui.ts
+++ b/extensions/skill-controller/ui.ts
@@ -29,8 +29,8 @@ function truncate(value: string, width: number): string {
  */
 const CHROME_ROWS_BASE = 11;
 
-/** Each skill occupies exactly 2 rendered rows (label + path). */
-const ROWS_PER_SKILL = 2;
+/** Each skill occupies exactly 3 rendered rows (name, state/source, path). */
+const ROWS_PER_SKILL = 3;
 
 /** Fallback when no height hint is available. */
 const DEFAULT_MAX_VISIBLE_SKILLS = 20;
@@ -182,8 +182,8 @@ export class SkillControllerOverlay implements Component, Focusable {
         const selected = absoluteIndex === this.selectedIndex;
         const state = this.getEnabled(skill) ? this.theme.fg("success", "enabled") : this.theme.fg("error", "disabled");
         const marker = selected ? this.theme.fg("accent", "▶") : " ";
-        const label = `${marker} ${skill.name} · ${state} · ${skill.sourceLabel}`;
-        rows.push(wrap(label));
+        rows.push(wrap(` ${marker} ${skill.name}`));
+        rows.push(wrap(`   ${state} · ${truncate(skill.sourceLabel, inner - 5)}`));
         rows.push(wrap(`   ${truncate(skill.relativeSkillDirPath, inner - 3)}`));
       }
 
@@ -206,7 +206,7 @@ export class SkillControllerOverlay implements Component, Focusable {
 
 /**
  * Compute the maximum number of skills that fit in the overlay given an
- * available overlay height. Accounts for chrome rows and 2 rows per skill,
+ * available overlay height. Accounts for chrome rows and 3 rows per skill,
  * plus up to 2 scroll-indicator rows.
  */
 export function maxSkillsForHeight(overlayHeight: number): number {

--- a/tests/skill-controller.ui-scroll.test.ts
+++ b/tests/skill-controller.ui-scroll.test.ts
@@ -106,12 +106,12 @@ describe("maxSkillsForHeight", () => {
   });
 
   it("computes expected values for common terminal heights", () => {
-    // 24 rows: 24 - 11 chrome - 2 indicators = 11 available / 2 rows per skill = 5
-    expect(maxSkillsForHeight(24)).toBe(5);
-    // 40 rows: 40 - 13 = 27 / 2 = 13
-    expect(maxSkillsForHeight(40)).toBe(13);
-    // 60 rows: 60 - 13 = 47 / 2 = 23
-    expect(maxSkillsForHeight(60)).toBe(23);
+    // 24 rows: 24 - 11 chrome - 2 indicators = 11 available / 3 rows per skill = 3
+    expect(maxSkillsForHeight(24)).toBe(3);
+    // 40 rows: 40 - 13 = 27 / 3 = 9
+    expect(maxSkillsForHeight(40)).toBe(9);
+    // 60 rows: 60 - 13 = 47 / 3 = 15
+    expect(maxSkillsForHeight(60)).toBe(15);
   });
 });
 
@@ -124,6 +124,17 @@ describe("overlay with 40+ skills", () => {
     for (const skill of skills) {
       expect(text).toContain(skill.name);
     }
+  });
+
+  it("splits skill rows into name, state/source, and relative path for readability", () => {
+    const skills = createSkills(1);
+    const { overlay } = createOverlay(skills, 5);
+    const lines = overlay.render(120);
+    const nameLineIndex = lines.findIndex((line) => line.includes("▶ skill-000"));
+
+    expect(nameLineIndex).toBeGreaterThanOrEqual(0);
+    expect(lines[nameLineIndex + 1]).toContain("enabled · ~/.pi/agent/skills");
+    expect(lines[nameLineIndex + 2]).toContain("skills/skill-0");
   });
 
   it("limits visible skills to maxVisibleSkills", () => {


### PR DESCRIPTION
## Summary
- Improve skill-controller modal list spacing and visual formatting.
- Adjust scroll/list rendering tests for the updated modal formatting.
- Update CHANGELOG.md for the fix.

Closes #7

## Verification
- git diff --check
- npm run typecheck
- npm test